### PR TITLE
Added /leaderboard/ endpoint

### DIFF
--- a/django-tb-react/djback/djback/urls.py
+++ b/django-tb-react/djback/djback/urls.py
@@ -25,5 +25,7 @@ urlpatterns = [
     path('tasks/', TaskView.as_view(), name='tasks'),
     path('profile/', ProfileView.as_view(), name='profile_view'),
     path('register/', RegisterView.as_view(), name='register'),
-    path('logout/', LogoutView.as_view(), name="logout")
+    path('logout/', LogoutView.as_view(), name="logout"),
+    path('leaderboard/', LeaderboardView.as_view(), name='leaderboard'),
+    path('leaderboard/<int:count>', LeaderboardView.as_view(), name='leaderboard_with_count'),
 ]

--- a/django-tb-react/djback/tb/serializers.py
+++ b/django-tb-react/djback/tb/serializers.py
@@ -18,3 +18,15 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ['id', 'username', 'first_name', 'last_name', 'email', 'date_joined', 'last_login', 'token']
 
+class LeaderboardSerializer(serializers.ModelSerializer):
+    rank = serializers.SerializerMethodField()
+    completed_tasks = serializers.IntegerField()
+
+    def get_rank(self, obj):
+        top_users = self.context.get('top_users')
+        rank = list(top_users).index(obj) + 1
+        return rank
+
+    class Meta:
+        model = User
+        fields = ("rank", "username", "completed_tasks")

--- a/django-tb-react/djback/tb/views.py
+++ b/django-tb-react/djback/tb/views.py
@@ -16,6 +16,7 @@ from django.utils.decorators import method_decorator
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
+from django.db.models import Count, Q
 
 from .models import *
 from .serializers import *
@@ -125,3 +126,9 @@ class LogoutView(APIView):
         except Exception as e:
             print(e)
             return Response({'error' : 'Invalid Token'}, status=status.HTTP_401_UNAUTHORIZED)
+
+class LeaderboardView(APIView):
+    def get(self, request, count=10):
+        top_users = User.objects.annotate(completed_tasks=Count("task", filter=Q(task__completed=True))).order_by("-completed_tasks")[:count]
+        serializer = LeaderboardSerializer(top_users, many=True, context={'top_users' : top_users})
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Returns a list of `{rank, username, completed tasks}`
`/leaderboard/n` returns the top `n` users